### PR TITLE
Update dependencies so we can train it on A6000/A100

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,17 @@ QPIC is implemented by extending the recently proposed object detector, DETR. QP
 ## Preparation
 
 ### Dependencies
-Our implementation uses external libraries such as NumPy and PyTorch. You can resolve the dependencies with the following command.
+Our implementation uses external libraries such as NumPy and PyTorch. You can resolve the dependencies with the following command. (The following are changed from the origin due to issues with Ampere architecture Nvidia GPUs.)
+
 ```
-pip install numpy
-pip install -r requirements.txt
+virtualenv qpic
+source qpic/bin/activate
+pip install torch==1.8.1+cu111 torchvision==0.9.1+cu111 torchaudio==0.8.1 -f https://download.pytorch.org/whl/torch_stable.html
+pip install git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI&egg=pycocotools
+pip install git+https://github.com/cocodataset/panopticapi.git#egg=panopticapi
+pip install scipy cython submitit
 ```
+
 Note that this command may dump errors during installing pycocotools, but the errors can be ignored.
 
 ### Dataset


### PR DESCRIPTION
* PyTorch 1.8.1 is the most recent version of PyTorch that can run qpic
* Older versions of PyTorch depend on older CUDA libraries, which do not 
   perform well on A100 or A6000 (Ampere architecture)
 